### PR TITLE
match flask pattern to return extra headers

### DIFF
--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -234,15 +234,28 @@ def validate(
 
             if (
                 isinstance(res, tuple)
-                and len(res) == 2
+                and len(res) in [2, 3]
                 and isinstance(res[0], BaseModel)
             ):
-                return make_json_response(
+                headers = None
+                status = on_success_status
+                if isinstance(res[1], (dict, tuple, list)):
+                    headers = res[1]
+                elif len(res) == 3 and isinstance(res[2], (dict, tuple, list)):
+                    status = res[1]
+                    headers = res[2]
+                else:
+                    status = res[1]
+
+                ret = make_json_response(
                     res[0],
-                    res[1],
+                    status,
                     exclude_none=exclude_none,
                     by_alias=response_by_alias,
                 )
+                if headers:
+                    ret.headers.update(headers)
+                return ret
 
             return res
 

--- a/tests/func/test_app.py
+++ b/tests/func/test_app.py
@@ -76,6 +76,22 @@ def app_with_custom_root_type(app):
 
 
 @pytest.fixture
+def app_with_custom_headers(app):
+    @app.route("/custom_headers", methods=["GET"])
+    @validate()
+    def custom_headers():
+        return {"test": 1}, {"CUSTOM_HEADER": "UNIQUE"}
+
+
+@pytest.fixture
+def app_with_custom_headers_status(app):
+    @app.route("/custom_headers_status", methods=["GET"])
+    @validate()
+    def custom_headers():
+        return {"test": 1}, 201, {"CUSTOM_HEADER": "UNIQUE"}
+
+
+@pytest.fixture
 def app_with_camel_route(app):
     def to_camel(x: str) -> str:
         first, *rest = x.split("_")
@@ -188,6 +204,22 @@ def test_custom_root_types(client):
         json=[{"name": "Joshua Bardwell", "age": 46}, {"name": "Andrew Cambden"}],
     )
     assert response.json == {"number": 2}
+
+
+@pytest.mark.usefixtures("app_with_custom_headers")
+def test_custom_headers(client):
+    response = client.get("/custom_headers")
+    assert response.json == {"test": 1}
+    assert response.status_code == 200
+    assert response.headers.get("CUSTOM_HEADER") == "UNIQUE"
+
+
+@pytest.mark.usefixtures("app_with_custom_headers_status")
+def test_custom_headers(client):
+    response = client.get("/custom_headers_status")
+    assert response.json == {"test": 1}
+    assert response.status_code == 201
+    assert response.headers.get("CUSTOM_HEADER") == "UNIQUE"
 
 
 @pytest.mark.usefixtures("app_with_array_route")


### PR DESCRIPTION
Technically Flask allows you to return from a route with a tuple of 3
items with the last item being a dictionary of headers. The docs mention
it here: https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses
This adjusts the behavior of the validate decorator to allow this as
well. Matches the behavior in: https://github.com/pallets/flask/blob/64213fc0214c1044fa2c9e60d0e2683e75d125c0/src/flask/app.py#L1644-L1646