### PR TITLE
allow custom error responses to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,12 @@ For more complete examples see [example application](https://github.com/bauerji/
 The behaviour can be configured using flask's application config
 `FLASK_PYDANTIC_VALIDATION_ERROR_STATUS_CODE` - response status code after validation error (defaults to `400`)
 
+Additionally, you can set `FLASK_PYDANTIC_VALIDATION_ERROR_RAISE` to `True` to cause
+`flask_pydantic.ValidationError` to be raised with either `body_params`,
+`form_params`, `path_params`, or `query_params` set as a list of error
+dictionaries. You can use `flask.Flask.register_error_handler` to catch that
+exception and fully customize the output response for a validation error.
+
 ## Contributing
 
 Feature requests and pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/flask_pydantic/__init__.py
+++ b/flask_pydantic/__init__.py
@@ -1,2 +1,3 @@
 from .core import validate  # noqa: F401
+from .exceptions import ValidationError  # noqa: F401
 from .version import __version__  # noqa: F401

--- a/flask_pydantic/exceptions.py
+++ b/flask_pydantic/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 
 class BaseFlaskPydanticException(Exception):
@@ -30,3 +30,21 @@ class ManyModelValidationError(BaseFlaskPydanticException):
 
     def errors(self):
         return self._errors
+
+
+class ValidationError(BaseFlaskPydanticException):
+    """This exception is raised if there is a failure during validation if the
+    user has configured an exception to be raised instead of a response"""
+
+    def __init__(
+        self,
+        body_params: Optional[List[dict]] = None,
+        form_params: Optional[List[dict]] = None,
+        path_params: Optional[List[dict]] = None,
+        query_params: Optional[List[dict]] = None,
+    ):
+        super().__init__()
+        self.body_params = body_params
+        self.form_params = form_params
+        self.path_params = path_params
+        self.query_params = query_params


### PR DESCRIPTION
By defining a new config value that flask_pydantic looks for
(FLASK_PYDANTIC_VALIDATION_ERROR_RAISE), we can support raising an
exception when we have a validation error. If that is set and the
exception is raised, by default, Flask will respond with a 500 error.
However, by coupling that feature with `Flask.register_error_handler`,
the user can catch the thrown exception and return whatever custom error
response the user wishes. Fixes https://github.com/bauerji/flask-pydantic/issues/45.