### PR TITLE
TypeError: Object of type ValueError is not JSON serializable

### DIFF
--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -243,6 +243,9 @@ def validate(
                     status_code = current_app.config.get(
                         "FLASK_PYDANTIC_VALIDATION_ERROR_STATUS_CODE", 400
                     )
+                    for idx, body_param in enumerate(err.get("body_params")):
+                        if "ctx" in body_param:
+                            del err["body_params"][idx]["ctx"]
                     return make_response(
                         jsonify({"validation_error": err}), status_code
                     )


### PR DESCRIPTION
Pydantic's erros() method contains a field called ctx.  If you try to create response json if ctx is included, it cannot be serialized.

## Version
* Python 3.11.6
* flask-pydantic 0.12.0
* flask3.0.0
* pydantic 2.5.3

## Sample code
```py
from typing import Optional

from flask import Flask
from flask_pydantic import validate
from pydantic import BaseModel, field_validator

app = Flask(__name__)


class ResponseModel(BaseModel):
    id: int
    age: int
    name: str
    nickname: Optional[str]


class RequestBodyModel(BaseModel):
    name: str
    nickname: Optional[str]

    @field_validator("name")
    def check_name(cls, v, values, **kwargs):
        if v != "hawksnowlog":
            raise ValueError()
        return v


@app.route("/", methods=["POST"])
@validate()
def post(body: RequestBodyModel):
    name = body.name
    nickname = body.nickname
    return ResponseModel(name=name, nickname=nickname, id=0, age=1000)
```

## Result
request

```
curl -v localhost:5000 -XPOST -d '{"name":"hawksnowlog3","nickname":"hawk"}' -H 'content-type: application/json'
```

* Actual

```
TypeError: Object of type ValueError is not JSON serializable
```

* Expect

```
{
  "validation_error": {
    "body_params": [
      {
        "input": "hawksnowlog3",
        "loc": [
          "name"
        ],
        "msg": "Value error, ",
        "type": "value_error",
        "url": "https://errors.pydantic.dev/2.5/v/value_error"
      }
    ]
  }
}
```

Thanks.