### PR TITLE
Fix CI on macOS runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,22 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest]
+        exclude:  # Python 3.7 is not supported on Apple ARM64
+          - python-version: "3.7"
+            os: macos-latest
+        include: # Python 3.7 is tested with a x86 macOS version
+          - python-version: "3.7"
+            os: macos-13
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: requirements/*.pip
     - name: Install dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements/test.pip


### PR DESCRIPTION
Following the CI failing on PR #92.

This PR contains the following:

- Checkout workflow updated to v4
- Setup python workflow updated to v5
- Fix python pip cache in CI
- Test python 3.7 against macOS x86 instead of ARM

Fix #93